### PR TITLE
upgrade descript-audiotools to 0.7.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ modelscope>=1.13.0
 # pandas>=2.0.0
 json5>=0.9.16
 munch>=4.0.0
-descript-audiotools
+git+https://github.com/descriptinc/audiotools@0.7.4#egg=descript-audiotools
 einops
 ffmpy
 docstring-parser


### PR DESCRIPTION
descript-audiotools 最新版本是 0.7.4，但是没有发布到 PyPI 上，导致 pip install 安装的是 0.7.2。
而 descript-audiotools 0.7.2 依赖的 protobuf 版本过于低（为 3.19.6），与其它依赖高版本 protobuf（比如 4.25.8）的节点有冲突。因此需要升级到 0.7.4。

试用下来，ComfyUI-Index-TTS 节点的 TTS2 工作流在 descript-audiotools 0.7.4 上是可以正常运行的。

但此改动需要保证系统中预先安装了 `git-lfs`，`pip install -r requirements.txt` 才可以正常运行。