### PR TITLE
Fix IndexTTS2 emotion vector demo parity

### DIFF
--- a/emotion_vector_node.py
+++ b/emotion_vector_node.py
@@ -7,25 +7,26 @@ class IndexTTSEmotionVectorNode:
     """
     ComfyUI node: Index TTS Emotion Vector
     - Outputs an emotion vector as JSON string for Index TTS 2's `emo_vector` input.
-    - Matches HF demo with 8 sliders: Happy, Angry, Sad, Fear, Hate, Love, Surprise, Neutral
+    - Matches HF demo with 8 sliders: Happy, Angry, Sad, Fear, Hate, Low, Surprise, Neutral
     - Optional random sampling (seeded) when you want quick stochastic presets.
     """
 
     EMO_ORDER = [
-        "Happy", "Angry", "Sad", "Fear", "Hate", "Love", "Surprise", "Neutral"
+        "Happy", "Angry", "Sad", "Fear", "Hate", "Low", "Surprise", "Neutral"
     ]
+    EMO_VECTOR_BIAS = np.array([0.75, 0.70, 0.80, 0.80, 0.75, 0.75, 0.55, 0.45], dtype=np.float32)
 
     @classmethod
     def INPUT_TYPES(cls):
         sliders = {
-            "Happy": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Angry": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Sad": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Fear": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Hate": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Love": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Surprise": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Neutral": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
+            "Happy": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Angry": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Sad": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Fear": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Hate": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Low": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Surprise": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Neutral": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
         }
         return {
             "required": {
@@ -57,6 +58,14 @@ class IndexTTSEmotionVectorNode:
             vec = vec / s
         return vec.tolist()
 
+    @classmethod
+    def _normalize_like_demo(cls, vec: List[float]) -> List[float]:
+        tmp = np.array([max(0.0, float(x)) for x in vec], dtype=np.float32) * cls.EMO_VECTOR_BIAS
+        total = float(tmp.sum())
+        if total > 0.8:
+            tmp = tmp * (0.8 / total)
+        return tmp.tolist()
+
     def build_vector(
         self,
         Happy: float,
@@ -64,23 +73,20 @@ class IndexTTSEmotionVectorNode:
         Sad: float,
         Fear: float,
         Hate: float,
-        Love: float,
+        Low: float,
         Surprise: float,
         Neutral: float,
         random_sampling: bool = False,
         seed: int = 0,
         normalize: bool = True,
         top_k_random: int = 2,
+        Love=None,
     ) -> Tuple[str]:
         if random_sampling:
             vec = self._sample_random_vector(seed, top_k_random)
         else:
-            vec = [Happy, Angry, Sad, Fear, Hate, Love, Surprise, Neutral]
+            low_value = Low if Love is None else Love
+            vec = [Happy, Angry, Sad, Fear, Hate, low_value, Surprise, Neutral]
             if normalize:
-                s = float(sum(max(0.0, float(x)) for x in vec))
-                if s > 0:
-                    vec = [float(max(0.0, float(x)))/s for x in vec]
-                else:
-                    # fallback to neutral
-                    vec = [0.0]*7 + [1.0]
+                vec = self._normalize_like_demo(vec)
         return (json.dumps(vec, ensure_ascii=False),)

--- a/index_tts2_mode_nodes.py
+++ b/index_tts2_mode_nodes.py
@@ -8,6 +8,16 @@ from .indextts2 import IndexTTS2Loader, IndexTTS2Engine
 # Global shared loader/engine to avoid duplicating model weights across nodes
 _GLOBAL_LOADER = IndexTTS2Loader()
 _GLOBAL_ENGINE = IndexTTS2Engine(_GLOBAL_LOADER)
+_EMO_VECTOR_BIAS = (0.75, 0.70, 0.80, 0.80, 0.75, 0.75, 0.55, 0.45)
+
+
+def _normalize_emo_vector_like_demo(vec):
+    tmp = np.array([max(0.0, float(x)) for x in vec], dtype=np.float32)
+    tmp = tmp * np.array(_EMO_VECTOR_BIAS, dtype=np.float32)
+    total = float(tmp.sum())
+    if total > 0.8:
+        tmp = tmp * (0.8 / total)
+    return tmp.tolist()
 
 
 class _IndexTTS2BaseMixin:
@@ -51,12 +61,12 @@ class _IndexTTS2BaseMixin:
             # Advanced generation parameters
             "do_sample_mode": (["off", "on"], {"default": "on"}),
             "temperature": ("FLOAT", {"default": 0.8, "min": 0.1, "max": 2.0, "step": 0.05}),
-            "top_p": ("FLOAT", {"default": 0.9, "min": 0.0, "max": 1.0, "step": 0.01}),
+            "top_p": ("FLOAT", {"default": 0.8, "min": 0.0, "max": 1.0, "step": 0.01}),
             "top_k": ("INT", {"default": 30, "min": 0, "max": 100, "step": 1}),
             "num_beams": ("INT", {"default": 3, "min": 1, "max": 10, "step": 1}),
             "repetition_penalty": ("FLOAT", {"default": 10.0, "min": 1.0, "max": 10.0, "step": 0.1}),
             "length_penalty": ("FLOAT", {"default": 0.0, "min": -2.0, "max": 2.0, "step": 0.1}),
-            "max_mel_tokens": ("INT", {"default": 1815, "min": 50, "max": 1815, "step": 5}),
+            "max_mel_tokens": ("INT", {"default": 1500, "min": 50, "max": 1815, "step": 10}),
             "max_tokens_per_sentence": ("INT", {"default": 120, "min": 0, "max": 600, "step": 5}),
             "seed": ("INT", {"default": 0, "min": 0, "max": 2**32 - 1}),
             # External cache control dict from utility node
@@ -85,8 +95,8 @@ class IndexTTS2BaseNode(_IndexTTS2BaseMixin):
         self.engine = _GLOBAL_ENGINE
 
     def generate(self, text, reference_audio, mode,
-                 do_sample_mode="off", temperature=0.8, top_p=0.9, top_k=30, num_beams=3,
-                 repetition_penalty=10.0, length_penalty=0.0, max_mel_tokens=1815,
+                 do_sample_mode="on", temperature=0.8, top_p=0.8, top_k=30, num_beams=3,
+                 repetition_penalty=10.0, length_penalty=0.0, max_mel_tokens=1500,
                  max_tokens_per_sentence=120, seed=0, return_subtitles=True,
                  cache_control=None):
         ref = self._process_audio_input(reference_audio)
@@ -115,8 +125,7 @@ class IndexTTS2EmotionAudioNode(_IndexTTS2BaseMixin):
         opt = cls._common_optional().copy()
         opt.update({
             "emo_ref_audio": ("AUDIO",),
-            # Align with upstream UI range 0~1.4
-            "emotion_weight": ("FLOAT", {"default": 0.8, "min": 0.0, "max": 1.4, "step": 0.05}),
+            "emotion_weight": ("FLOAT", {"default": 0.8, "min": 0.0, "max": 1.0, "step": 0.01}),
         })
         return {"required": cls._base_inputs(), "optional": opt}
 
@@ -132,8 +141,8 @@ class IndexTTS2EmotionAudioNode(_IndexTTS2BaseMixin):
     def generate(self, text, reference_audio, mode, emo_ref_audio,
                  emotion_weight=0.8,
                  
-                 do_sample_mode="off", temperature=0.8, top_p=0.9, top_k=30, num_beams=3,
-                 repetition_penalty=10.0, length_penalty=0.0, max_mel_tokens=1815,
+                 do_sample_mode="on", temperature=0.8, top_p=0.8, top_k=30, num_beams=3,
+                 repetition_penalty=10.0, length_penalty=0.0, max_mel_tokens=1500,
                  max_tokens_per_sentence=120, seed=0, return_subtitles=True,
                  cache_control=None):
         ref = self._process_audio_input(reference_audio)
@@ -144,7 +153,7 @@ class IndexTTS2EmotionAudioNode(_IndexTTS2BaseMixin):
             do_sample=(do_sample_mode == "on"), temperature=temperature, top_p=top_p, top_k=top_k, num_beams=num_beams,
             repetition_penalty=repetition_penalty, length_penalty=length_penalty,
             max_mel_tokens=max_mel_tokens, max_tokens_per_sentence=max_tokens_per_sentence,
-            emo_text=None, emo_ref_audio=emo_ref, emo_vector=None, emo_weight=float(emotion_weight),
+            emo_text=None, emo_ref_audio=emo_ref, emo_vector=None, emo_weight=float(emotion_weight) * 0.8,
             seed=seed, return_subtitles=True,
         )
         try:
@@ -162,15 +171,14 @@ class IndexTTS2EmotionVectorNode(_IndexTTS2BaseMixin):
         opt = cls._common_optional().copy()
         # 8 sliders in-node
         opt.update({
-            # Align with upstream UI range 0~1.4 for each component
-            "Happy": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Angry": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Sad": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Fear": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Hate": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Love": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Surprise": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
-            "Neutral": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.4, "step": 0.01}),
+            "Happy": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Angry": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Sad": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Fear": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Hate": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Low": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Surprise": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
+            "Neutral": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.05}),
         })
         return {"required": cls._base_inputs(), "optional": opt}
 
@@ -184,16 +192,16 @@ class IndexTTS2EmotionVectorNode(_IndexTTS2BaseMixin):
         self.engine = IndexTTS2Engine(self.loader)
 
     def generate(self, text, reference_audio, mode,
-                 Happy=0.0, Angry=0.0, Sad=0.0, Fear=0.0, Hate=0.0, Love=0.0, Surprise=0.0, Neutral=0.0,
+                 Happy=0.0, Angry=0.0, Sad=0.0, Fear=0.0, Hate=0.0, Low=0.0, Surprise=0.0, Neutral=0.0,
                  
-                 do_sample_mode="off", temperature=0.8, top_p=0.9, top_k=30, num_beams=3,
-                 repetition_penalty=10.0, length_penalty=0.0, max_mel_tokens=1815,
+                 do_sample_mode="on", temperature=0.8, top_p=0.8, top_k=30, num_beams=3,
+                 repetition_penalty=10.0, length_penalty=0.0, max_mel_tokens=1500,
                  max_tokens_per_sentence=120, seed=0, return_subtitles=True,
-                 cache_control=None):
+                 cache_control=None, Love=None):
         ref = self._process_audio_input(reference_audio)
-        vec = [Happy, Angry, Sad, Fear, Hate, Love, Surprise, Neutral]
-        s = float(sum(max(0.0, float(x)) for x in vec))
-        emo_vec = ([float(max(0.0, float(x)))/s for x in vec] if s > 0 else [0.0]*7 + [1.0])
+        low_value = Low if Love is None else Love
+        vec = [Happy, Angry, Sad, Fear, Hate, low_value, Surprise, Neutral]
+        emo_vec = _normalize_emo_vector_like_demo(vec)
         out = self._do_generate(
             self.engine,
             text=text, reference_audio=ref, mode=mode,
@@ -232,8 +240,8 @@ class IndexTTS2EmotionTextNode(_IndexTTS2BaseMixin):
 
     def generate(self, text, reference_audio, mode, emotion_description="",
                  
-                 do_sample_mode="off", temperature=0.8, top_p=0.9, top_k=30, num_beams=3,
-                 repetition_penalty=10.0, length_penalty=0.0, max_mel_tokens=1815,
+                 do_sample_mode="on", temperature=0.8, top_p=0.8, top_k=30, num_beams=3,
+                 repetition_penalty=10.0, length_penalty=0.0, max_mel_tokens=1500,
                  max_tokens_per_sentence=120, seed=0, return_subtitles=True,
                  cache_control=None):
         ref = self._process_audio_input(reference_audio)


### PR DESCRIPTION
﻿## Summary
- Align IndexTTS2 emotion vector slider normalization with the official Hugging Face demo.
- Keep an all-zero emotion vector as all zeros instead of forcing 100% Neutral.
- Rename the sixth emotion dimension from Love to Low and align demo defaults for `top_p`, `max_mel_tokens`, slider ranges, and emotion audio weight scaling.

## Root cause
The ComfyUI node normalized non-empty vectors to sum to 1 and fell back to Neutral=1 when every slider was zero. The upstream demo keeps zero vectors at zero and applies per-emotion bias plus a total cap of 0.8, so the local behavior changed timbre even when users expected no emotion override.

## Validation
- `python -m py_compile .\index_tts2_mode_nodes.py .\emotion_vector_node.py .\indextts2\infer.py`
- Checked helper vector output: all-zero sliders now return `[0,0,0,0,0,0,0,0]`.
